### PR TITLE
Config option to apply to JSX files too

### DIFF
--- a/lib/jsfmtRunner.coffee
+++ b/lib/jsfmtRunner.coffee
@@ -25,6 +25,9 @@ class JsfmtRunner
     atom.commands.add 'atom-workspace',
         'atom-jsfmt:format-all-open-files', => @formatAllOpen()
 
+    @scopes = ['source.js']
+    @scopes.push 'source.js.jsx' if atom.config.get 'atom-jsfmt.applyToJSXFiles'
+
     # Message panel that we'll share between editors
     @messagePanel = new MessagePanelView
         title: 'jsfmt'
@@ -111,7 +114,7 @@ class JsfmtRunner
 
   # Is the given editor editing javascript?
   @editorIsJs: (editor) ->
-    return editor.getGrammar().scopeName is 'source.js'
+    return @scopes.indexOf(editor.getGrammar().scopeName) > -1
 
   # Given an error message, returns its line number.
   @errorToLineNumber: (error) ->

--- a/main.coffee
+++ b/main.coffee
@@ -14,6 +14,11 @@ module.exports =
       description: 'Should files be formatted automatically on save?'
       type: 'boolean'
       default: 'true'
+    applyToJSXFiles:
+      title: 'Apply to JSX files (.jsx)'
+      description: 'Formats files with the .jsx extension. You should have a jsfmt rule to ignore the actual JSX'
+      type: 'boolean'
+      default: 'false'
 
   # Start things up
   activate: ->


### PR DESCRIPTION
Added a quick config option to turn on `jsfmt` for JSX files (those with scope source.js.jsx).

This is `off` by default, so the behaviour is the same as the current package.