### PR TITLE
Fix jsfmt not working with Atom's content security policy

### DIFF
--- a/lib/jsfmtRunner.coffee
+++ b/lib/jsfmtRunner.coffee
@@ -3,7 +3,8 @@
 # This replaces jsfmt.coffee and doesn't rely on spawning a child process
 #
 
-jsfmt = require 'jsfmt'
+{allowUnsafeNewFunction} = require 'loophole'
+jsfmt = allowUnsafeNewFunction -> require 'jsfmt'
 fs = require 'fs'
 path = require 'path'
 findNearestFile = require 'nearest-file'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "atom-message-panel": "^1.2.4",
     "atom-space-pen-views": "^2.0.3",
-    "jsfmt": "0.5.1",
-    "nearest-file": "^0.1.0"
+    "jsfmt": "0.5.3",
+    "nearest-file": "^0.1.0",
+    "loophole": "^1.1.0"
   }
 }


### PR DESCRIPTION
This patch fixes an error with newer versions of jsfmt:

```
Failed to activate package named 'atom-jsfmt' EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".
```

It is caused by Atom's Content Security Policy. The workaround uses [loophole](https://github.com/atom/loophole).

I also took the opportunity to bump jsfmt's version!
